### PR TITLE
Open up grape dependency beyond 0.x.

### DIFF
--- a/grape-cache_control.gemspec
+++ b/grape-cache_control.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency 'grape', '~> 0.3'
+  spec.add_runtime_dependency 'grape'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Grape 1.0.0 is in beta and it doesn't break any compatibility with grape-cache_control.