### PR TITLE
Updated gem grape version

### DIFF
--- a/grape-cache_control.gemspec
+++ b/grape-cache_control.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency 'grape', '~> 0.3'
+  spec.add_dependency 'grape', '>= 0.3', '< 2'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Added dependancy update for the gem grape `'>= 0.3', '< 2'`. During update to the ruby version 3, `gem grape` not compatible with older versions of grape and this gem creates a dependancy.